### PR TITLE
1/2: Allow loading of properties from vendor/overlay/local.prop

### DIFF
--- a/init/property_service.c
+++ b/init/property_service.c
@@ -603,6 +603,7 @@ void load_all_props(void)
 {
     load_properties_from_file(PROP_PATH_SYSTEM_BUILD, NULL);
     load_properties_from_file(PROP_PATH_SYSTEM_DEFAULT, NULL);
+    load_properties_from_file(PROP_PATH_VENDOR_DEFAULT, NULL);
     load_properties_from_file(PROP_PATH_FACTORY, "ro.*");
 
     /* Read vendor-specific property runtime overrides. */


### PR DESCRIPTION
Is to compliment Runtime Resource overlays if using custom properties

Change-Id: Idc68c22cfb74c9c8bb12c57cd6061e03ea06fadc

Move VENDOR_DEFAULT to load all props

Change-Id: I1390d5549e6f691c1a2a1256de9589c19ff0f06a